### PR TITLE
Fix that Doctrine set the column to `not null` in MySQL

### DIFF
--- a/src/Field/ImageServiceListField.php
+++ b/src/Field/ImageServiceListField.php
@@ -17,13 +17,7 @@ class ImageServiceListField extends FieldTypeBase
     public function getStorageType(){
         return 'text';
     }
-
-    public function getStorageOptions(){
-        return [
-            'default' => ''
-        ];
-    }
-
+    
     public function getTemplate(){
         return '_' . $this->getName() . '.twig';
     }


### PR DESCRIPTION
In the database check, Bolt complained each time that the corresponding column of an `imageservicelist` field is not the correct scheme. This small change (removing the default value) fixes that. My assumptions are:
- Doctrine sets the default value to an empty string and therefore sets the column to `NOT NULL`
- In MySQL, `text` [types cannot have a default value](https://dev.mysql.com/doc/refman/5.7/en/blob.html) and therefore the default value of an empty string is ignored
- Strange things happen

This is *not* tested with PostgreSQL